### PR TITLE
add "extra" slot to button

### DIFF
--- a/packages/oceanfront/src/components/Button.ts
+++ b/packages/oceanfront/src/components/Button.ts
@@ -121,9 +121,11 @@ export const OfButton = defineComponent({
             )
           : undefined
 
+      const extraContent = ctx.slots.extra?.()
       const body = [
         iconContent,
         mainContent,
+        extraContent,
         items && !split ? expand : undefined,
       ]
       return h(


### PR DESCRIPTION
the slot is rendered inside the button like "content" and label, but it
does not affect CSS class (and layout).
Intended for rendering popups together with the button