### PR TITLE
#145 - Fix style for x and y in Calendar : Not transparent BG

### DIFF
--- a/packages/oceanfront/src/scss/_calendar.scss
+++ b/packages/oceanfront/src/scss/_calendar.scss
@@ -270,6 +270,7 @@ div.of-date-picker-cur-year {
 
 .of-calendar-gutter,
 .of-calendar-day-supertitle {
+  background-color: var(--calendar-day-color);
   border-left: solid 1px var(--calendar-grid-color);
   border-right: solid 1px var(--calendar-grid-color);
   &.of-week-number {
@@ -294,6 +295,7 @@ div.of-date-picker-cur-year {
   display: flex;
   justify-content: center;
   padding-bottom: 2px;
+  background-color: var(--calendar-day-color);
 }
 
 .of-calendar-day-title {


### PR DESCRIPTION
fix for
`It looks like the header section doesn't apply to the basic Oceanfront calendar, so this might be more of an app-js issue. I think that the default style for the very top and left columns in the calendar should probably have a semi-transparent or opaque background (Mon/Tue/22/23 here, as well as the corner):`