### PR TITLE
Options list updates

### DIFF
--- a/packages/demo/src/components/SelectInputs.vue
+++ b/packages/demo/src/components/SelectInputs.vue
@@ -411,8 +411,7 @@ export default defineComponent({
     ]
     timezones.sort()
     const tzOpts = { items: [] as Record<string, any>[] }
-    //const tzValue = ref('America/Vancouver')
-    const tzValue = ref('')
+    const tzValue = ref('America/Vancouver')
     let tzGrp = null
     for (const value of timezones) {
       const gPos = value.indexOf('/')

--- a/packages/demo/src/components/SelectInputs.vue
+++ b/packages/demo/src/components/SelectInputs.vue
@@ -411,7 +411,8 @@ export default defineComponent({
     ]
     timezones.sort()
     const tzOpts = { items: [] as Record<string, any>[] }
-    const tzValue = ref('America/Vancouver')
+    //const tzValue = ref('America/Vancouver')
+    const tzValue = ref('')
     let tzGrp = null
     for (const value of timezones) {
       const gPos = value.indexOf('/')

--- a/packages/oceanfront/src/components/ListItem.ts
+++ b/packages/oceanfront/src/components/ListItem.ts
@@ -108,7 +108,7 @@ export const OfListItem = defineComponent({
                 },
                 href: link.href,
                 ref: elt,
-                tabIndex: active ? 0 : -1,
+                tabIndex: active || props.attrs?.isFocused ? 0 : -1,
                 onClick(evt: MouseEvent) {
                   if (evt.button != null && evt.button !== 0) return
                   activate(evt)

--- a/packages/oceanfront/src/components/OptionList.vue
+++ b/packages/oceanfront/src/components/OptionList.vue
@@ -63,6 +63,7 @@ import {
   Ref,
   nextTick,
   watch,
+  onMounted,
 } from 'vue'
 import { OfNavGroup } from '../components/NavGroup'
 import { OfListItem } from '../components/ListItem'
@@ -113,11 +114,21 @@ const OfOptionList = defineComponent({
     watch(searchText, () => {
       if (searchText.value.trim() === '') theItems.value = props.items
       theItems.value = props.items.filter((item) => {
+        if (item.special) return true
         if (item.value !== undefined) {
           const optionText: string = item.text
           return optionText
             .toLowerCase()
             .includes(searchText.value.trim().toLowerCase())
+        }
+      })
+      //Remove empty special items
+      theItems.value = theItems.value.filter((item, index) => {
+        if (item.special) {
+          const nextItem = theItems.value[index + 1] ?? null
+          return nextItem && !nextItem.special
+        } else {
+          return true
         }
       })
     })
@@ -164,6 +175,23 @@ const OfOptionList = defineComponent({
       showSearch.value = false
       searchText.value = ''
     }
+
+    const focusFirstItem = () => {
+      //If there is selected item it is alredy focused
+      const selected = theItems.value.find(
+        (item) => item.selected && item.selected === true
+      )
+      if (selected) return true
+
+      theItems.value.some((item) => {
+        if (!item.special) {
+          item.attrs = { ...item.attrs, ...{ isFocused: true } }
+          return true
+        }
+      })
+    }
+
+    focusFirstItem()
 
     return {
       isEmpty,

--- a/packages/oceanfront/src/components/OptionList.vue
+++ b/packages/oceanfront/src/components/OptionList.vue
@@ -63,7 +63,6 @@ import {
   Ref,
   nextTick,
   watch,
-  onMounted,
 } from 'vue'
 import { OfNavGroup } from '../components/NavGroup'
 import { OfListItem } from '../components/ListItem'


### PR DESCRIPTION
1. Not remove special (group) items from the list in search result
2. Focus on the first item of OptionList if there is no selected item. We can't navigate and activate search by items list while it's out on focus   