### PR TITLE
Toggle control in fixed mode looks like editable #193

### DIFF
--- a/packages/oceanfront/src/scss/_fields.scss
+++ b/packages/oceanfront/src/scss/_fields.scss
@@ -817,3 +817,14 @@
   width: 2.5em;
   height: 1.2em;
 }
+
+.of-field.of-toggle-field.of--mode-fixed {
+  .of-switch {
+    .of-switch-track {
+      opacity: .2;
+    }
+    .of-switch-thumb {
+      opacity: .3;
+    }
+  }
+}


### PR DESCRIPTION
As an example, I took this one
https://vuetifyjs.com/en/components/switches/#states

<img width="826" alt="image" src="https://user-images.githubusercontent.com/10978098/196671998-0a3bc467-d463-4b4d-ad9b-589551fefe66.png">
this is how it looks in oceanfront

<img width="298" alt="image" src="https://user-images.githubusercontent.com/10978098/196672245-26a06588-6231-4528-b7d5-a747e73499df.png">
<img width="191" alt="image" src="https://user-images.githubusercontent.com/10978098/196672299-5785caba-cff1-4f2b-a917-441d0f6270d9.png">

PR