### PR TITLE
Fix defines in vite config

### DIFF
--- a/packages/oceanfront-html-editor/vite.config.ts
+++ b/packages/oceanfront-html-editor/vite.config.ts
@@ -19,11 +19,6 @@ export default defineConfig(({ command, mode }) => {
         // the proper extensions will be added
         fileName: 'oceanfront-html-editor',
       },
-      define: {
-        __DEV__: JSON.stringify(dev),
-        __VUE_OPTIONS_API__: 'true',
-        __VUE_PROD_DEVTOOLS__: 'false',
-      },
       emptyOutDir: !dev,
       rollupOptions: {
         // make sure to externalize deps that shouldn't be bundled
@@ -40,7 +35,13 @@ export default defineConfig(({ command, mode }) => {
         },
       },
       reportCompressedSize: !dev,
-      sourcemap: !dev,
+      sourcemap: true,
+    },
+    define: {
+      __DEV__: JSON.stringify(dev),
+      __VUE_OPTIONS_API__: 'true',
+      __VUE_PROD_DEVTOOLS__: 'false',
+      'process.env.NODE_ENV': JSON.stringify(mode),
     },
     plugins,
   }

--- a/packages/oceanfront/vite.config.ts
+++ b/packages/oceanfront/vite.config.ts
@@ -19,11 +19,6 @@ export default defineConfig(({ command, mode }) => {
         // the proper extensions will be added
         fileName: 'oceanfront',
       },
-      define: {
-        __DEV__: JSON.stringify(dev),
-        __VUE_OPTIONS_API__: 'true',
-        __VUE_PROD_DEVTOOLS__: 'false',
-      },
       emptyOutDir: !dev,
       rollupOptions: {
         // make sure to externalize deps that shouldn't be bundled
@@ -40,7 +35,13 @@ export default defineConfig(({ command, mode }) => {
         },
       },
       reportCompressedSize: !dev,
-      sourcemap: !dev,
+      sourcemap: true,
+    },
+    define: {
+      __DEV__: JSON.stringify(dev),
+      __VUE_OPTIONS_API__: 'true',
+      __VUE_PROD_DEVTOOLS__: 'false',
+      'process.env.NODE_ENV': JSON.stringify(mode),
     },
     plugins,
   }

--- a/packages/of-colorscheme-editor/vite.config.ts
+++ b/packages/of-colorscheme-editor/vite.config.ts
@@ -19,11 +19,6 @@ export default defineConfig(({ command, mode }) => {
         // the proper extensions will be added
         fileName: 'oceanfront-colorscheme-editor',
       },
-      define: {
-        __DEV__: JSON.stringify(dev),
-        __VUE_OPTIONS_API__: 'true',
-        __VUE_PROD_DEVTOOLS__: 'false',
-      },
       emptyOutDir: !dev,
       rollupOptions: {
         // make sure to externalize deps that shouldn't be bundled
@@ -40,7 +35,13 @@ export default defineConfig(({ command, mode }) => {
         },
       },
       reportCompressedSize: !dev,
-      sourcemap: !dev,
+      sourcemap: true,
+    },
+    define: {
+      __DEV__: JSON.stringify(dev),
+      __VUE_OPTIONS_API__: 'true',
+      __VUE_PROD_DEVTOOLS__: 'false',
+      'process.env.NODE_ENV': JSON.stringify(mode),
     },
     plugins,
   }


### PR DESCRIPTION
This removes references to `process.env` and `__DEV__` in the built packages, and also enables source maps for dev builds.