### PR TITLE
Separate tab header text

### DIFF
--- a/packages/oceanfront/src/components/Tabs.vue
+++ b/packages/oceanfront/src/components/Tabs.vue
@@ -70,7 +70,8 @@
                 <div class="of--layer of--layer-outl" />
                 <div class="of-tab-text">
                   <of-icon v-if="tab.icon" :name="tab.icon" size="1.1em" />
-                  {{ tab.text }}
+                  <span>{{ tab.text }}</span>
+
                 </div>
                 <div class="of--layer of--layer-state" />
               </div>


### PR DESCRIPTION
I separated of-tab header item text in <span/> so we can manage it's visibility or styles , we needed it in ListView