### PR TITLE
Persist Kanban board column collapse state in local storage

### DIFF
--- a/packages/oceanfront/src/components/KanbanBoard/utils/index.ts
+++ b/packages/oceanfront/src/components/KanbanBoard/utils/index.ts
@@ -173,3 +173,21 @@ export function debounce<T extends (...args: any[]) => void>(
     timeoutId = window.setTimeout(() => fn.apply(this, args), delay)
   }
 }
+
+export const getCollapsedColumns = (storageKey: string): string[] => {
+  const stored = localStorage.getItem(storageKey)
+  if (stored) {
+    try {
+      return JSON.parse(stored)
+    } catch {
+      return []
+    }
+  }
+  return []
+}
+
+export const saveCollapsedState = (storageKey: string, columns: string[]) => {
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(columns))
+  } catch {}
+}


### PR DESCRIPTION
- Added storage key generation based on board ID
- Implemented functions to save and retrieve collapsed column state
- Updated column collapse handling to use immutable state updates
- Added watch to save collapsed columns when state changes