### PR TITLE
App Bar: Make a redesign #3303

### DIFF
--- a/packages/oceanfront/src/components/Tabs.vue
+++ b/packages/oceanfront/src/components/Tabs.vue
@@ -57,6 +57,7 @@
                 (tab.params as any)?.className
               ]"
               role="tab"
+              :id="tab.id"
               :aria-label="tab.ariaLabel"
               :aria-haspopup="showSubMenu"
               :aria-selected="selectedTabKey === tab.key"
@@ -64,11 +65,12 @@
               <div class="of--layer of--layer-bg" />
               <div class="of--layer of--layer-brd" />
               <div class="of--layer of--layer-outl" />
-              <div class="of-tab-text">
+              <div :class="['of-tab-text', { 'only-icon': !tab.text }]">
                 <of-icon v-if="tab.icon" :name="tab.icon" scale="1.1em" />
-                <span>{{ tab.text }}</span>
+                <span v-if="tab.text">{{ tab.text }}</span>
               </div>
               <div class="of--layer of--layer-state" />
+              <div v-if="tab.count" class="of-tab-count">{{ tab.count }}</div>
             </div>
           </template>
           <div class="of-tabs-line" ref="tabLine"></div>
@@ -104,6 +106,13 @@
             <template #option-icon="item"
               ><slot name="submenu-option-icon" v-bind="item"
             /></template>
+            <template
+              v-for="(item, index) in subMenuSlots"
+              :key="index"
+              #[index]
+            >
+              <component :is="item" />
+            </template>
           </of-option-list>
         </slot>
       </of-overlay>
@@ -173,7 +182,7 @@ const formatItems = (
     let subMenu = undefined
     text = item[params.textKey] ? item[params.textKey] : ''
 
-    if (text === '') continue
+    if (text === '' && !item[params.iconKey]) continue
 
     if (visible && item.visible === false) {
       continue
@@ -200,8 +209,11 @@ const formatItems = (
       params: item.params ?? undefined,
       attrs: item.attrs ?? undefined,
       subMenuItems: subMenu,
+      subMenuSlots: item.subMenuSlots,
       field: item.field,
-      class: item.class ?? undefined
+      class: item.class ?? undefined,
+      id: item.id,
+      count: item.count > 99 ? '99+' : item.count
     } as Tab)
   }
 
@@ -672,6 +684,7 @@ export default defineComponent({
     const subMenuTabsList: Ref<Tab[]> = ref([])
     const subMenuTimerId = ref()
     const submenuMinWidth = ref(0)
+    const subMenuSlots = ref()
 
     const openSubMenu = (
       key: number,
@@ -689,6 +702,7 @@ export default defineComponent({
           subMenuTimerId.value = window.setTimeout(
             () => {
               subMenuTabsList.value = tab.subMenuItems ?? []
+              subMenuSlots.value = tab.subMenuSlots ?? []
               subMenuOuter.value = elt
               subMenuActive.value = true
               openedMenuTabKey.value = key
@@ -924,6 +938,7 @@ export default defineComponent({
       overlayClassname,
       showSubMenu,
       subMenuTabsList,
+      subMenuSlots,
       subMenuActive,
       subMenuOuter,
       openSubMenu,

--- a/packages/oceanfront/src/lib/tab.ts
+++ b/packages/oceanfront/src/lib/tab.ts
@@ -8,6 +8,9 @@ export interface Tab {
   icon?: string
   disabled?: boolean
   subMenuItems?: Array<Tab> | undefined
+  subMenuSlots?: Array<object> | undefined
   parentKey?: number | undefined
   ariaLabel?: string | undefined
+  id?: string
+  count?: number
 }

--- a/packages/oceanfront/src/scss/_tabs.scss
+++ b/packages/oceanfront/src/scss/_tabs.scss
@@ -24,7 +24,7 @@
     mat-bg,
     (transparent, 0%),
     (
-      hover: var(--of-primary-tint) 6%,
+      hover: var(--of-primary-tint) 6%
     )
   );
   @include define-color-opacity(
@@ -32,7 +32,7 @@
     (var(--of-color-on-background), 100%),
     (
       active: var(--of-primary-tint) 100%,
-      disabled: var(--of-color-on-background) 38%,
+      disabled: var(--of-color-on-background) 38%
     )
   );
   @include define-color-opacity(mat-st, (transparent, 0), ());
@@ -42,14 +42,14 @@
     (transparent, 0%),
     (
       hover: var(--of-primary-tint) 6%,
-      active: var(--of-color-surface) 100%,
+      active: var(--of-color-surface) 100%
     )
   );
   @include define-color-opacity(
     att-brd,
     (--of-primary-tint, 100%),
     (
-      active: var(--of-primary-tint) 100%,
+      active: var(--of-primary-tint) 100%
     )
   );
   @include define-color-opacity(
@@ -57,7 +57,7 @@
     (var(--of-color-on-background), 100%),
     (
       active: var(--of-primary-tint) 100%,
-      disabled: var(--of-color-on-background) 38%,
+      disabled: var(--of-color-on-background) 38%
     )
   );
   @include define-color-opacity(att-st, (transparent, 0), ());
@@ -67,7 +67,7 @@
     (transparent, 0%),
     (
       hover: var(--of-color-inverse-surface) 60%,
-      active: var(--of-color-inverse-surface) 60%,
+      active: var(--of-color-inverse-surface) 60%
     )
   );
   @include define-color-opacity(
@@ -76,13 +76,15 @@
     (
       hover: var(--of-color-inverse-on-surface) 100%,
       active: var(--of-color-inverse-on-surface) 100%,
-      disabled: var(--of-color-on-surface) 38%,
+      disabled: var(--of-color-on-surface) 38%
     )
   );
   @include define-color-opacity(osx-st, (transparent, 0), ());
 
   --of-tab-border-radius: 6px;
   --of-tab-osx-border-color: var(--of-color-outline);
+  --of-tab-count-background-color: #a21515;
+  --of-tab-count-color: #fff;
 }
 
 /** Styling */
@@ -218,12 +220,29 @@
         display: flex;
         align-items: center;
 
+        .of-tab-count {
+          background-color: var(--of-tab-count-background-color);
+          color: var(--of-tab-count-color);
+          font-weight: normal;
+          border-radius: 50%;
+          width: 17px;
+          height: 17px;
+          position: absolute;
+          top: -1px;
+          z-index: 2;
+          right: 0px;
+          font-size: 9px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+
         .of-tab-text {
           z-index: 2;
           display: flex;
           color: var(--tab-color);
           opacity: var(--tab-opacity);
-          & > .of-icon {
+          &:not(.only-icon) > .of-icon {
             margin-right: 0.4em;
           }
         }


### PR DESCRIPTION
- Added `id` and `count` properties to the Tab interface.
- Updated Tabs.vue to include tab IDs and conditional rendering for tab counts.
- Introduced dynamic sub-menu slot rendering for improved flexibility.
- Enhanced SCSS styles for tab count display, including background and text color adjustments.