### PR TITLE
Refactor Vite configuration for Oceanfront package

### DIFF
--- a/packages/oceanfront/vite.config.mts
+++ b/packages/oceanfront/vite.config.mts
@@ -23,21 +23,13 @@ export default defineConfig(({ command, mode }): any => {
       lib: {
         entry: resolve(__dirname, 'src/index.ts'),
         name: 'oceanfront',
-        // the proper extensions will be added
-        fileName: 'oceanfront'
+        fileName: 'oceanfront',
+        formats: ['es']
       },
       emptyOutDir: !dev,
       rollupOptions: {
-        // make sure to externalize deps that shouldn't be bundled
-        // into your library
         external: ['vue'],
         output: {
-          // Provide global variables to use in the UMD build
-          // for externalized deps
-          globals: {
-            vue: 'Vue'
-          },
-          // Rename combined CSS output from style.css
           assetFileNames: 'oceanfront.[ext]'
         }
       },


### PR DESCRIPTION
- Updated library configuration to specify output formats as ES modules.
- Removed unnecessary comments and cleaned up the rollupOptions for clarity.